### PR TITLE
Fixes to API

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
     coverage: codecov
     envs:
     # Code style
-    - linux: pycodestyle
+    - linux: style
     # Standard tests
     - linux: py36-test
     - linux: py37-test

--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -1,5 +1,5 @@
-from .version import version as __version__
 from ._distutils_helpers import get_compiler
-from ._setup_helpers import get_extensions, pkg_config
 from ._openmp_helpers import add_openmp_flags_if_available
+from ._setup_helpers import get_extensions, pkg_config
 from ._utils import import_file, write_if_different
+from .version import version as __version__

--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -1,4 +1,5 @@
 from .version import version as __version__
-from ._setup_helpers import get_extensions
+from ._distutils_helpers import get_compiler
+from ._setup_helpers import get_extensions, pkg_config
 from ._openmp_helpers import add_openmp_flags_if_available
 from ._utils import import_file, write_if_different

--- a/extension_helpers/_distutils_helpers.py
+++ b/extension_helpers/_distutils_helpers.py
@@ -17,6 +17,8 @@ from distutils.errors import DistutilsError
 
 from ._utils import silence
 
+__all__ = ['get_compiler']
+
 
 def get_dummy_distribution():
     """
@@ -94,8 +96,9 @@ def get_distutils_build_option(option):
     return get_distutils_option(option, ['build', 'build_ext', 'build_clib'])
 
 
-def get_compiler_option():
-    """ Determines the compiler that will be used to build extension modules.
+def get_compiler():
+    """
+    Determines the compiler that will be used to build extension modules.
 
     Returns
     -------

--- a/extension_helpers/_distutils_helpers.py
+++ b/extension_helpers/_distutils_helpers.py
@@ -10,7 +10,6 @@ utilities in this module do not have that restriction.
 
 import os
 import sys
-
 from distutils import ccompiler
 from distutils.dist import Distribution
 from distutils.errors import DistutilsError

--- a/extension_helpers/_openmp_helpers.py
+++ b/extension_helpers/_openmp_helpers.py
@@ -18,11 +18,10 @@ import time
 import datetime
 import tempfile
 import subprocess
-
 from distutils import log
+from distutils.errors import LinkError, CompileError
 from distutils.ccompiler import new_compiler
-from distutils.sysconfig import customize_compiler, get_config_var
-from distutils.errors import CompileError, LinkError
+from distutils.sysconfig import get_config_var, customize_compiler
 
 from ._distutils_helpers import get_compiler
 

--- a/extension_helpers/_openmp_helpers.py
+++ b/extension_helpers/_openmp_helpers.py
@@ -24,7 +24,7 @@ from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler, get_config_var
 from distutils.errors import CompileError, LinkError
 
-from ._distutils_helpers import get_compiler_option
+from ._distutils_helpers import get_compiler
 
 __all__ = ['add_openmp_flags_if_available']
 
@@ -120,7 +120,7 @@ def get_openmp_flags():
     compile_flags = []
     link_flags = []
 
-    if get_compiler_option() == 'msvc':
+    if get_compiler() == 'msvc':
         compile_flags.append('-openmp')
     else:
 

--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -4,20 +4,19 @@ This module contains a number of utilities for use during
 setup/build/packaging that are useful to astropy as a whole.
 """
 
-from collections import defaultdict
 import os
-import subprocess
 import sys
 import shutil
-
+import subprocess
 from distutils import log
+from collections import defaultdict
 from distutils.core import Extension
 
 from setuptools import find_packages
 from setuptools.config import read_configuration
 
 from ._distutils_helpers import get_compiler
-from ._utils import walk_skip_hidden, import_file
+from ._utils import import_file, walk_skip_hidden
 
 __all__ = ['get_extensions', 'pkg_config']
 

--- a/extension_helpers/_utils.py
+++ b/extension_helpers/_utils.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import contextlib
 import os
 import sys
 import glob
-
+import contextlib
 from importlib import machinery as import_machinery
 
 __all__ = ['write_if_different', 'import_file']

--- a/extension_helpers/tests/__init__.py
+++ b/extension_helpers/tests/__init__.py
@@ -1,6 +1,6 @@
 import os
-import subprocess as sp
 import sys
+import subprocess as sp
 
 import pytest
 

--- a/extension_helpers/tests/test_setup_helpers.py
+++ b/extension_helpers/tests/test_setup_helpers.py
@@ -1,15 +1,13 @@
 import os
 import sys
 import importlib
+from textwrap import dedent
 
 import pytest
 
-from textwrap import dedent
-
 from .._setup_helpers import get_extensions
-
 from . import reset_distutils_log  # noqa
-from . import run_setup, cleanup_import
+from . import cleanup_import, run_setup
 
 extension_helpers_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,3 +41,14 @@ norecursedirs =
     .tox
     extension_helpers/tests/package_template
 python_functions = test_
+
+[isort]
+line_length = 100
+sections = FUTURE,STDLIB,THIRDPARTY,NUMPY,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_first_party = extension_helpers
+known_numpy = numpy
+multi_line_output = 0
+balanced_wrapping = True
+include_trailing_comma = false
+length_sort_stdlib = true

--- a/tox.ini
+++ b/tox.ini
@@ -42,8 +42,12 @@ commands =
     test: pytest --pyargs extension_helpers {toxinidir}/docs --cov extension_helpers {posargs}
     build_docs: sphinx-build -W -b html . _build/html {posargs}
 
-[testenv:pycodestyle]
+[testenv:style]
 skip_install = true
-description = invoke pycodestyle on package code
-deps = pycodestyle
-commands = pycodestyle extension_helpers --max-line-length=100
+description = invoke pycodestyle and isort on package code
+deps =
+    pycodestyle
+    isort
+commands =
+    pycodestyle extension_helpers --max-line-length=100
+    isort -c -rc extension_helpers


### PR DESCRIPTION
This exposes two functions in the public API (which were previously exposed in astropy-helpers): ``pkg_config`` and ``get_compiler`` (formerly ``get_compiler_option``). These functions are needed for astropy core.