### PR TITLE
MNT: Replace master with main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing to extension-helpers
 
 The guidelines for contributing to ``extension-helpers`` are generally the same
 as the [contributing guidelines for the astropy core
-package](http://github.com/astropy/astropy/blob/master/CONTRIBUTING.md).
+package](http://github.com/astropy/astropy/blob/main/CONTRIBUTING.md).
 Basically, report relevant issues in the ``extension-helpers`` issue tracker, and
 we welcome pull requests that broadly follow the [Astropy coding
 guidelines](http://docs.astropy.org/en/latest/development/codeguide.html).

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 extension-helpers
 =================
 
-.. image:: https://dev.azure.com/astropy-project/extension-helpers/_apis/build/status/astropy.extension-helpers?branchName=master
-  :target: https://dev.azure.com/astropy-project/extension-helpers/_build/latest?definitionId=4&branchName=master
+.. image:: https://dev.azure.com/astropy-project/extension-helpers/_apis/build/status/astropy.extension-helpers?branchName=main
+  :target: https://dev.azure.com/astropy-project/extension-helpers/_build/latest?definitionId=4&branchName=main
 
-.. image:: https://codecov.io/gh/astropy/extension-helpers/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/astropy/extension-helpers/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/astropy/extension-helpers
 
 The **extension-helpers** package includes convenience helpers to assist with

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ schedules:
   displayName: 'Weekly cron'
   branches:
     include:
-    - master
+    - main
   always: 'true'
 
 jobs:


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #27 