### PR TITLE
Skip hypothesis tests in downstream testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ changedir = test: .tmp/downstream
 commands =
     pip install setuptools setuptools_scm wheel cython numpy
     pip install --no-build-isolation "git+https://github.com/astropy/astropy#egg=astropy[test]"
-    pytest --pyargs astropy
+    pytest --pyargs astropy -m "not hypothesis"
     pip install --no-build-isolation "git+https://github.com/sunpy/sunpy#egg=sunpy[all,tests]"
     pytest --pyargs sunpy
 


### PR DESCRIPTION
We don't really need to run these as they can be flaky and time consuming.