### PR TITLE
Support Apple clang specific compilation/linking flags to enable OpenMP

### DIFF
--- a/extension_helpers/_openmp_helpers.py
+++ b/extension_helpers/_openmp_helpers.py
@@ -22,7 +22,7 @@ import subprocess
 
 from setuptools.command.build_ext import customize_compiler, get_config_var, new_compiler
 
-from ._setup_helpers import get_compiler
+from ._setup_helpers import check_apple_clang, get_compiler
 
 __all__ = ['add_openmp_flags_if_available']
 
@@ -134,8 +134,12 @@ def get_openmp_flags():
             link_flags.append('-L' + lib_path)
             link_flags.append('-Wl,-rpath,' + lib_path)
 
-        compile_flags.append('-fopenmp')
-        link_flags.append('-fopenmp')
+        if not check_apple_clang():
+            compile_flags.append('-fopenmp')
+            link_flags.append('-fopenmp')
+        else:
+            compile_flags.append('-Xpreprocessor -fopenmp')
+            link_flags.append('-lomp')
 
     return {'compiler_flags': compile_flags, 'linker_flags': link_flags}
 

--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -12,7 +12,7 @@ import subprocess
 from collections import defaultdict
 
 from setuptools import Extension, find_packages
-from setuptools.command.build_ext import new_compiler
+from setuptools.command.build_ext import customize_compiler,new_compiler
 
 from ._utils import import_file, walk_skip_hidden
 
@@ -34,6 +34,29 @@ def get_compiler():
 
     """
     return new_compiler().compiler_type
+
+
+def check_apple_clang():
+    """
+    Detemines if compiler that will be used to build extension modules is
+    'Apple Clang' (which requires a specific management of OpenMP compilation
+    and linking flags).
+
+    Returns
+    -------
+    apple_clang : bool
+        Indicator whether current compiler is 'Apple Clang'.
+    """
+    try:
+        ccompiler = new_compiler()
+        customize_compiler(ccompiler)
+        compiler_version = subprocess.run(
+            [ccompiler.compiler[0], "--version"], capture_output=True
+        )
+        apple_clang = "Apple clang" in str(compiler_version.stdout)
+    except:
+        apple_clang = False
+    return apple_clang
 
 
 def get_extensions(srcdir='.'):

--- a/extension_helpers/tests/test_setup_helpers.py
+++ b/extension_helpers/tests/test_setup_helpers.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 import pytest
 
-from .._setup_helpers import get_compiler, get_extensions
+from .._setup_helpers import check_apple_clang, get_compiler, get_extensions
 from . import cleanup_import, run_setup
 
 extension_helpers_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))  # noqa
@@ -26,6 +26,9 @@ POSSIBLE_COMPILERS = ['unix', 'msvc', 'bcpp', 'cygwin', 'mingw32']
 
 def test_get_compiler():
     assert get_compiler() in POSSIBLE_COMPILERS
+
+def test_check_apple_clang():
+    assert check_apple_clang() in [True, False]
 
 
 def _extension_test_package(tmpdir, request, extension_type='c',


### PR DESCRIPTION
Potential fix for #40 

Apple clang requires `-Xpreprocessor -fopenmp` compile flags (instead of just `-fopenmp`) and `-lomp` linking flags (instead of ` -fopenmp`) to support and enable OpenMp.

Work in progress, I am still not sure whether it works or not on MacOS.
