### PR TITLE
Support enabling via `pyproject.toml`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
   recommends the ``-Qopenmp`` flag rather than ``-fopenmp`` for greater
   performance.
 
+* Add support for enabling extension-helpers from pyproject.toml. [#48]
+
 1.0.0 (2022-03-16)
 ------------------
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -45,3 +45,13 @@ It is also possible to enable extension-helpers in ``setup.cfg`` instead of
 
     [extension-helpers]
     use_extension_helpers = true
+
+Moreover, one can also enable extension-helpers in ``pyproject.toml`` by adding
+the following configuration to the ``pyproject.toml`` file::
+
+    [tool.extension-helpers]
+    use_extension_helpers = true
+
+.. note::
+  For backwards compatibility, the setting of ``use_extension_helpers`` in
+  ``setup.cfg`` will override any setting of it in ``pyproject.toml``.

--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -12,6 +12,7 @@ def _finalize_distribution_hook(distribution):
     from setup.cfg without the need for setup.py.
     """
     import os
+    import tomli
     from pathlib import Path
 
     config_files = distribution.find_config_files()
@@ -29,16 +30,11 @@ def _finalize_distribution_hook(distribution):
 
     pyproject = Path(distribution.src_root or os.curdir, "pyproject.toml")
     if pyproject.exists() and not found_config:
-        try:
-            import tomli
-        except ImportError:
-            pass
-        else:
-            with pyproject.open("rb") as f:
-                pyproject_cfg = tomli.load(f)
-                if ('tool' in pyproject_cfg and 
-                    'extension-helpers' in (tools := pyproject_cfg['tool']) and 
-                    'use_extension_helpers' in (exn := tools['extension-helpers']) and
-                    exn['use_extension_helpers']):
+        with pyproject.open("rb") as f:
+            pyproject_cfg = tomli.load(f)
+            if ('tool' in pyproject_cfg and 
+                'extension-helpers' in (tools := pyproject_cfg['tool']) and 
+                'use_extension_helpers' in (exn := tools['extension-helpers']) and
+                exn['use_extension_helpers']):
 
-                    distribution.ext_modules = get_extensions()
+                distribution.ext_modules = get_extensions()

--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -11,11 +11,34 @@ def _finalize_distribution_hook(distribution):
     Entry point for setuptools which allows extension-helpers to be enabled
     from setup.cfg without the need for setup.py.
     """
+    import os
+    from pathlib import Path
+
     config_files = distribution.find_config_files()
     if len(config_files) == 0:
         return
+
     cfg = ConfigParser()
     cfg.read(config_files[0])
-    if (cfg.has_option("extension-helpers", "use_extension_helpers") and
-            cfg.get("extension-helpers", "use_extension_helpers").lower() == 'true'):
-        distribution.ext_modules = get_extensions()
+    found_config = False
+    if cfg.has_option("extension-helpers", "use_extension_helpers"):
+        found_config = True
+
+        if cfg.get("extension-helpers", "use_extension_helpers").lower() == 'true':
+            distribution.ext_modules = get_extensions()
+
+    pyproject = Path(distribution.src_root or os.curdir, "pyproject.toml")
+    if pyproject.exists() and not found_config:
+        try:
+            import tomli
+        except ImportError:
+            pass
+        else:
+            with pyproject.open("rb") as f:
+                pyproject_cfg = tomli.load(f)
+                if ('tool' in pyproject_cfg and 
+                    'extension-helpers' in (tools := pyproject_cfg['tool']) and 
+                    'use_extension_helpers' in (exn := tools['extension-helpers']) and
+                    exn['use_extension_helpers']):
+
+                    distribution.ext_modules = get_extensions()

--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -34,8 +34,8 @@ def _finalize_distribution_hook(distribution):
         with pyproject.open("rb") as f:
             pyproject_cfg = tomli.load(f)
             if ('tool' in pyproject_cfg and
-                    'extension-helpers' in (tools := pyproject_cfg['tool']) and
-                    'use_extension_helpers' in (exn := tools['extension-helpers']) and
-                    exn['use_extension_helpers']):
+                    'extension-helpers' in pyproject_cfg['tool'] and
+                    'use_extension_helpers' in pyproject_cfg['tool']['extension-helpers'] and
+                    pyproject_cfg['tool']['extension-helpers']['use_extension_helpers']):
 
                 distribution.ext_modules = get_extensions()

--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -12,8 +12,9 @@ def _finalize_distribution_hook(distribution):
     from setup.cfg without the need for setup.py.
     """
     import os
-    import tomli
     from pathlib import Path
+
+    import tomli
 
     config_files = distribution.find_config_files()
     if len(config_files) == 0:
@@ -32,9 +33,9 @@ def _finalize_distribution_hook(distribution):
     if pyproject.exists() and not found_config:
         with pyproject.open("rb") as f:
             pyproject_cfg = tomli.load(f)
-            if ('tool' in pyproject_cfg and 
-                'extension-helpers' in (tools := pyproject_cfg['tool']) and 
-                'use_extension_helpers' in (exn := tools['extension-helpers']) and
-                exn['use_extension_helpers']):
+            if ('tool' in pyproject_cfg and
+                    'extension-helpers' in (tools := pyproject_cfg['tool']) and
+                    'use_extension_helpers' in (exn := tools['extension-helpers']) and
+                    exn['use_extension_helpers']):
 
                 distribution.ext_modules = get_extensions()

--- a/extension_helpers/tests/test_setup_helpers.py
+++ b/extension_helpers/tests/test_setup_helpers.py
@@ -184,7 +184,8 @@ def test_compiler_module(capsys, c_extension_test_package):
 
 
 @pytest.mark.parametrize('use_extension_helpers', [None, False, True])
-def test_no_setup_py(tmpdir, use_extension_helpers):
+@pytest.mark.parametrize('pyproject_use_helpers', [None, False, True])
+def test_no_setup_py(tmpdir, use_extension_helpers, pyproject_use_helpers):
     """
     Test that makes sure that extension-helpers can be enabled without a
     setup.py file.
@@ -242,12 +243,23 @@ def test_no_setup_py(tmpdir, use_extension_helpers):
             use_extension_helpers = {str(use_extension_helpers).lower()}
         """))
 
-    test_pkg.join('pyproject.toml').write(dedent("""\
-        [build-system]
-        requires = ["setuptools>=43.0.0",
-                    "wheel"]
-        build-backend = 'setuptools.build_meta'
-    """))
+    if pyproject_use_helpers is None:
+        test_pkg.join('pyproject.toml').write(dedent("""\
+            [build-system]
+            requires = ["setuptools>=43.0.0",
+                        "wheel"]
+            build-backend = 'setuptools.build_meta'
+        """))
+    else:
+        test_pkg.join('pyproject.toml').write(dedent(f"""\
+            [build-system]
+            requires = ["setuptools>=43.0.0",
+                        "wheel"]
+            build-backend = 'setuptools.build_meta'
+
+            [tool.extension-helpers]
+            use_extension_helpers = {str(pyproject_use_helpers).lower()}
+        """))
 
     install_temp = test_pkg.mkdir('install_temp')
 
@@ -267,7 +279,7 @@ def test_no_setup_py(tmpdir, use_extension_helpers):
 
         importlib.import_module(package_name)
 
-        if use_extension_helpers:
+        if use_extension_helpers or (use_extension_helpers is None and pyproject_use_helpers):
             compiler_version_mod = importlib.import_module(package_name + '.compiler_version')
             assert compiler_version_mod.compiler != 'unknown'
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ python_requires = >=3.7
 packages = find:
 install_requires =
     setuptools>=40.2
+    tomli>=1.0.0
 
 [options.package_data]
 extension_helpers = src/compiler.c


### PR DESCRIPTION
This should allow the setting of the `use_extension_helpers` option in the `pyproject.toml` file using:

```toml
[tool.extension-helpers]
use_extension_helpers = true
```

in addition to the already supported option of doing this in the `setup.cfg` file.

Fixes #47