### PR TITLE
get_extensions: use shutil.copyfile to avoid PermissionError

### DIFF
--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -95,7 +95,7 @@ def get_extensions(srcdir="."):
     if len(ext_modules) > 0:
         main_package_dir = min(packages, key=len)
         src_path = os.path.join(os.path.dirname(__file__), "src")
-        shutil.copy(
+        shutil.copyfile(
             os.path.join(src_path, "compiler.c"),
             os.path.join(srcdir, main_package_dir, "_compiler.c"),
         )


### PR DESCRIPTION
Without this change, packages that depend on this module (e.g astropy) may get a PermissionError on systems such as Nix and Guix. Because, when these systems attempt to build astropy, the built package `astropy-extrnsion-helpers` holds an `src/compiler.c` that has no write permissions - just like any other file in a built package in these systems. Then, when astropy tries to use the copied `_compiler.c`, it tries to open it with `wb+`. Using `shutil.copyfile` doesn't copy metadata.