### PR TITLE
Fix bug that caused extension-helpers to not work correctly if pyproject was the only configuration file present

### DIFF
--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -16,18 +16,16 @@ def _finalize_distribution_hook(distribution):
 
     import tomli
 
-    config_files = distribution.find_config_files()
-    if len(config_files) == 0:
-        return
-
-    cfg = ConfigParser()
-    cfg.read(config_files[0])
     found_config = False
-    if cfg.has_option("extension-helpers", "use_extension_helpers"):
-        found_config = True
 
-        if cfg.get("extension-helpers", "use_extension_helpers").lower() == "true":
-            distribution.ext_modules = get_extensions()
+    config_files = distribution.find_config_files()
+    if len(config_files) > 0:
+        cfg = ConfigParser()
+        cfg.read(config_files[0])
+        if cfg.has_option("extension-helpers", "use_extension_helpers"):
+            found_config = True
+            if cfg.get("extension-helpers", "use_extension_helpers").lower() == "true":
+                distribution.ext_modules = get_extensions()
 
     pyproject = Path(distribution.src_root or os.curdir, "pyproject.toml")
     if pyproject.exists() and not found_config:

--- a/extension_helpers/tests/test_setup_helpers.py
+++ b/extension_helpers/tests/test_setup_helpers.py
@@ -369,14 +369,16 @@ def test_only_pyproject(tmpdir, pyproject_use_helpers):
     if pyproject_use_helpers is None:
         extension_helpers_option = ""
     else:
-        extension_helpers_option = dedent(f"""
+        extension_helpers_option = dedent(
+            f"""
         [tool.extension-helpers]
         use_extension_helpers = {str(pyproject_use_helpers).lower()}
-        """)
+        """
+        )
 
     test_pkg.join("pyproject.toml").write(
-            dedent(
-                f"""\
+        dedent(
+            f"""\
             [project]
             name = "{package_name}"
             version = "0.1"
@@ -390,8 +392,10 @@ def test_only_pyproject(tmpdir, pyproject_use_helpers):
                         "cython"]
             build-backend = 'setuptools.build_meta'
 
-            """) + extension_helpers_option
+            """
         )
+        + extension_helpers_option
+    )
 
     install_temp = test_pkg.mkdir("install_temp")
 

--- a/extension_helpers/tests/test_setup_helpers.py
+++ b/extension_helpers/tests/test_setup_helpers.py
@@ -351,6 +351,8 @@ def test_only_pyproject(tmpdir, pyproject_use_helpers):
     setup.py and without a setup.cfg file.
     """
 
+    pytest.importorskip("setuptools", minversion="62.0")
+
     package_name = "helpers_test_package_" + str(uuid.uuid4()).replace("-", "_")
 
     test_pkg = tmpdir.mkdir("test_pkg")

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ test =
     pytest
     pytest-cov
     coverage>=4
+    cython
 docs =
     sphinx
     sphinx-automodapi


### PR DESCRIPTION
Without this I was seeing issues in projects after migrating setup.cfg -> pyproject.toml