### PR TITLE
Add back support for absolute source paths but deprecate it

### DIFF
--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -104,6 +104,29 @@ def get_extensions(srcdir="."):
         )
         ext_modules.append(ext)
 
+    # Since https://github.com/astropy/extension-helpers/pull/67,
+    # extensions that used absolute paths in source names stop working.
+    # Absolute paths in source paths are undesirable but we need to
+    # preserve backward-compatibility until we bump the major release,
+    # so we check for the case of absolute paths and emit a deprecation
+    # warning for now.
+    for extension in ext_modules:
+        sources = []
+        fixed = []
+        for source in extension.sources:
+            if os.path.isabs(source):
+                source = os.path.relpath(source)
+                fixed.append(source)
+            sources.append(source)
+        if fixed:
+            log.warn("Extension {0} contains source files "
+                     "({1}) that are specified using an absolute "
+                         "path, which will not be supported in future.".format(
+                            extension.name, ', '.join(fixed)
+                         ))
+
+        extension.sources = sources
+
     return ext_modules
 
 

--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -119,7 +119,7 @@ def get_extensions(srcdir="."):
                 fixed.append(source)
             sources.append(source)
         if fixed:
-            log.warn(
+            log.warning(
                 "Extension {} contains source files "
                 "({}) that are specified using an absolute "
                 "path, which will not be supported in future.".format(

--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -105,7 +105,7 @@ def get_extensions(srcdir="."):
         ext_modules.append(ext)
 
     # Since https://github.com/astropy/extension-helpers/pull/67,
-    # extensions that used absolute paths in source names stop working.
+    # extensions that used absolute paths in source names stopped working.
     # Absolute paths in source paths are undesirable but we need to
     # preserve backward-compatibility until we bump the major release,
     # so we check for the case of absolute paths and emit a deprecation
@@ -119,11 +119,13 @@ def get_extensions(srcdir="."):
                 fixed.append(source)
             sources.append(source)
         if fixed:
-            log.warn("Extension {0} contains source files "
-                     "({1}) that are specified using an absolute "
-                         "path, which will not be supported in future.".format(
-                            extension.name, ', '.join(fixed)
-                         ))
+            log.warn(
+                "Extension {} contains source files "
+                "({}) that are specified using an absolute "
+                "path, which will not be supported in future.".format(
+                    extension.name, ", ".join(fixed)
+                )
+            )
 
         extension.sources = sources
 

--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -115,7 +115,13 @@ def get_extensions(srcdir="."):
         fixed = []
         for source in extension.sources:
             if os.path.isabs(source):
-                source = os.path.relpath(source)
+                try:
+                    source = os.path.relpath(source)
+                except ValueError:
+                    # In some cases it's impossible to use a relative path, for
+                    # instance if the source files are on a different drive. In
+                    # this case there's not much we can do so we just proceed.
+                    pass
                 fixed.append(source)
             sources.append(source)
         if fixed:


### PR DESCRIPTION
@neutrinoceros - https://github.com/astropy/extension-helpers/pull/67 broke compilation for modules with extensions that were specified as absolute paths, which occurred once in astropy (https://github.com/astropy/astropy/pull/15663). The error was:

```
      writing manifest file 'astropy.egg-info/SOURCES.txt'
      error: Error: setup script specifies an absolute path:
      
          /Users/tom/Code/Astropy/astropy/./astropy/io/fits/hdu/compressed/src/compression.c
      
      setup() arguments must *always* be /-separated paths relative to the
      setup.py directory, *never* absolute paths.
```

Even though those modules should indeed use relative paths, we should ideally not break compatibility for all packages that were released in the past that use extension-helpers in pyproject.toml without any pinning, so this PR is a patch to restore compatibility but add a warning.