### PR TITLE
DEP: drop dependency on tomli on Python 3.11 and newer

### DIFF
--- a/extension_helpers/__init__.py
+++ b/extension_helpers/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from configparser import ConfigParser
 
 from ._openmp_helpers import add_openmp_flags_if_available  # noqa: F401
@@ -14,7 +15,10 @@ def _finalize_distribution_hook(distribution):
     import os
     from pathlib import Path
 
-    import tomli
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
 
     found_config = False
 
@@ -30,7 +34,7 @@ def _finalize_distribution_hook(distribution):
     pyproject = Path(distribution.src_root or os.curdir, "pyproject.toml")
     if pyproject.exists() and not found_config:
         with pyproject.open("rb") as f:
-            pyproject_cfg = tomli.load(f)
+            pyproject_cfg = tomllib.load(f)
             if (
                 "tool" in pyproject_cfg
                 and "extension-helpers" in pyproject_cfg["tool"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ python_requires = >=3.7
 packages = find:
 install_requires =
     setuptools>=40.2
-    tomli>=1.0.0
+    tomli>=1.0.0 ; python_version < '3.11'
 
 [options.package_data]
 extension_helpers = src/compiler.c


### PR DESCRIPTION
A simple enhancement for modern Python versions