### PR TITLE
TST: treat warnings as errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ docs =
 
 [tool:pytest]
 testpaths = "extension_helpers" "docs"
+filterwarnings =
+    error
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
This is to make the sort of problem dealt with in #67 easier to detect systematically