### PR TITLE
MNT: find and replace log.warn -> log.warning (the warn method is deprecated)

### DIFF
--- a/extension_helpers/_openmp_helpers.py
+++ b/extension_helpers/_openmp_helpers.py
@@ -252,13 +252,13 @@ def check_openmp_support(openmp_flags=None):
                 if len(output) == nthreads:
                     is_openmp_supported = True
                 else:
-                    log.warn(
+                    log.warning(
                         "Unexpected number of lines from output of test OpenMP "
                         "program (output was {})".format(output)
                     )
                     is_openmp_supported = False
             else:
-                log.warn(f"Unexpected output from test OpenMP program (output was {output})")
+                log.warning(f"Unexpected output from test OpenMP program (output was {output})")
                 is_openmp_supported = False
         except Exception:
             is_openmp_supported = False

--- a/extension_helpers/_setup_helpers.py
+++ b/extension_helpers/_setup_helpers.py
@@ -255,7 +255,7 @@ def pkg_config(packages, default_libraries, executable="pkg-config"):
             f"  returncode: {e.returncode}",
             f"  output: {e.output}",
         ]
-        log.warn("\n".join(lines))
+        log.warning("\n".join(lines))
         result["libraries"].extend(default_libraries)
     else:
         if pipe.returncode != 0:
@@ -263,7 +263,7 @@ def pkg_config(packages, default_libraries, executable="pkg-config"):
                 f"pkg-config could not lookup up package(s) {', '.join(packages)}.",
                 "This may cause the build to fail below.",
             ]
-            log.warn("\n".join(lines))
+            log.warning("\n".join(lines))
             result["libraries"].extend(default_libraries)
         else:
             for token in output.split():


### PR DESCRIPTION
A continuation of #67