### PR TITLE
TST: drop legacy pytest fixture tmpdir, use tmp_path instead

### DIFF
--- a/extension_helpers/tests/__init__.py
+++ b/extension_helpers/tests/__init__.py
@@ -97,8 +97,9 @@ setup(name=NAME, version=VERSION,
 """
 
 
-def create_testpackage(tmpdir, version="0.1"):
-    source = tmpdir.mkdir("testpkg")
+def create_testpackage(tmp_path, version="0.1"):
+    source = tmp_path / "testpkg"
+    os.mkdir(source)
 
     with source.as_cwd():
         source.mkdir("_extension_helpers_test_")
@@ -116,7 +117,7 @@ def create_testpackage(tmpdir, version="0.1"):
 
 
 @pytest.fixture
-def testpackage(tmpdir, version="0.1"):
+def testpackage(tmp_path, version="0.1"):
     """
     This fixture creates a simplified package called _extension_helpers_test_
     used primarily for testing ah_boostrap, but without using the
@@ -124,7 +125,7 @@ def testpackage(tmpdir, version="0.1"):
     extension_helpers package already under test.
     """
 
-    return create_testpackage(tmpdir, version=version)
+    return create_testpackage(tmp_path, version=version)
 
 
 def cleanup_import(package_name):

--- a/extension_helpers/tests/py311_backports.py
+++ b/extension_helpers/tests/py311_backports.py
@@ -1,0 +1,68 @@
+"""
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+"""
+import os
+from contextlib import AbstractContextManager
+
+
+# this class is vendored from Python 3.11.0
+class chdir(AbstractContextManager):
+    """Non thread-safe context manager to change the current working directory."""
+
+    def __init__(self, path):
+        self.path = path
+        self._old_cwd = []
+
+    def __enter__(self):
+        self._old_cwd.append(os.getcwd())
+        os.chdir(self.path)
+
+    def __exit__(self, *excinfo):
+        os.chdir(self._old_cwd.pop())

--- a/extension_helpers/tests/test_utils.py
+++ b/extension_helpers/tests/test_utils.py
@@ -4,16 +4,16 @@ import time
 from .._utils import import_file, write_if_different
 
 
-def test_import_file(tmpdir):
-    filename = str(tmpdir / "spam.py")
+def test_import_file(tmp_path):
+    filename = str(tmp_path / "spam.py")
     with open(filename, "w") as f:
         f.write("magic = 12345")
     module = import_file(filename)
     assert module.magic == 12345
 
 
-def test_write_if_different(tmpdir):
-    filename = str(tmpdir / "test.txt")
+def test_write_if_different(tmp_path):
+    filename = str(tmp_path / "test.txt")
     write_if_different(filename, b"abc")
     time1 = os.path.getmtime(filename)
     time.sleep(0.01)


### PR DESCRIPTION
A byproduct of my work on #80 (this branch is currently based off #80 to avoid conflicts after that one is merged)
[`tmpdir` is discouraged](https://docs.pytest.org/en/7.4.x/reference/reference.html#tmpdir)