### PR TITLE
Test downstream with Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           coverage: ''
 
         # Test downstream packages
-        - linux: py39-downstream
+        - linux: py312-downstream
 
   publish:
     needs: tests


### PR DESCRIPTION
Hopefully this should fix the downstream job (astropy core now requires Python 3.10)