### PR TITLE
MNT: Replace ubuntu-20.04 with ubuntu-22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
 
         # Test with more compilers, for the OpenMP helpers
         - macos: py39-test-osxclang-conda
+          runs-on: macos-13
           toxdeps: 'tox>=4'
           coverage: ''
         - linux: py39-test-linuxgcc-conda

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           posargs: --openmp-expected=False
         - macos: py313-test
           posargs: --openmp-expected=False
-          
+
         - windows: py38-test
           runs-on: windows-2019
         - windows: py312-test-devdeps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,14 +32,15 @@ jobs:
         - macos: py312-test-devdeps
           posargs: --openmp-expected=False
         - macos: py313-test
-
+          posargs: --openmp-expected=False
+          
         - windows: py38-test
           runs-on: windows-2019
         - windows: py312-test-devdeps
           runs-on: windows-2019
 
         # Test with more compilers, for the OpenMP helpers
-        - macos: py39-test-osxclang-conda
+        - macos: py311-test-osxclang-conda
           runs-on: macos-13
           toxdeps: 'tox>=4'
           coverage: ''

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,12 @@ jobs:
         - linux: py310-test
         - linux: py311-test
         - linux: py312-test
+        - linux: py313-test
         - linux: py312-test-devdeps
 
         - macos: py312-test-devdeps
           posargs: --openmp-expected=False
+        - macos: py313-test
 
         - windows: py38-test
           runs-on: windows-2019

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
   apt_packages:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
   apt_packages:
     - graphviz
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,8 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
   apt_packages:
     - graphviz
 


### PR DESCRIPTION
As recommended by actions/runner-images#11101 , this PR replaces the deprecated ubuntu-20.04 runner with a newer version. This also replaces RTD workflow, if applicable, to future-proof the build in case it follows suit.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/63)