### PR TITLE
Allow opting in to limited API builds with EXTENSION_HELPERS_PY_LIMITED_API

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -91,5 +91,10 @@ You can also set this option in ``pyproject.toml``, using::
 although note that this option is not formally documented/supported by the Python
 packaging infrastructure and may change in future.
 
-The ``get_extensions()`` functions will automatically detect this option and
+Alternatively, you can dynamically opt in to limited API builds by setting
+the ``EXTENSION_HELPERS_PY_LIMITED_API`` environment variable, e.g.::
+
+    EXTENSION_HELPERS_PY_LIMITED_API='cp311' python -m build
+
+The ``get_extensions()`` functions will automatically detect these options and
 add the necessary compiler flags to build your extension modules.

--- a/extension_helpers/_utils.py
+++ b/extension_helpers/_utils.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+import tempfile
 from configparser import ConfigParser
 from importlib import machinery as import_machinery
 from importlib.util import module_from_spec, spec_from_file_location
@@ -153,6 +154,21 @@ def get_limited_api_option(srcdir):
     Checks setup.cfg and pyproject.toml files in the current directory
     for the py_limited_api setting
     """
+
+    py_limited_api = os.environ.get("EXTENSION_HELPERS_PY_LIMITED_API")
+
+    if py_limited_api is not None:
+
+        if "DIST_EXTRA_CONFIG" in os.environ:
+            raise ValueError(
+                "Cannot use EXTENSION_HELPERS_PY_LIMITED_API if DIST_EXTRA_CONFIG is already defined"
+            )
+
+        dist_extra_config_filename = tempfile.mktemp()
+        with open(dist_extra_config_filename, "w") as f:
+            f.write(f"[bdist_wheel]\npy_limited_api={py_limited_api}")
+        os.environ["DIST_EXTRA_CONFIG"] = dist_extra_config_filename
+        return py_limited_api
 
     srcdir = Path(srcdir)
 


### PR DESCRIPTION
@neutrinoceros - just FYI, since you suggested this! :)

Also cc @lpsinger 