### PR TITLE
TST: Replace macos-13 with macos-14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
 
         # Test with more compilers, for the OpenMP helpers
         - macos: py313-test-osxclang-conda
-          runs-on: macos-13
+          runs-on: macos-14
           coverage: ''
         - linux: py310-test-linuxgcc-conda
           coverage: ''


### PR DESCRIPTION
https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down