### PR TITLE
FEAT: add support for automatic abi3 version selection

### DIFF
--- a/extension_helpers/_utils.py
+++ b/extension_helpers/_utils.py
@@ -3,11 +3,14 @@
 import os
 import re
 import sys
+import sysconfig
 import tempfile
 from configparser import ConfigParser
 from importlib import machinery as import_machinery
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+
+from packaging import tags
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -157,8 +160,20 @@ def get_limited_api_option(srcdir):
 
     py_limited_api = os.environ.get("EXTENSION_HELPERS_PY_LIMITED_API")
 
-    if py_limited_api is not None:
+    if py_limited_api == "auto":
+        template = "{interpreter}-{abi}-{platform}"
+        interpreter_id = f"{tags.interpreter_name()}{tags.interpreter_version()}"
+        abi3_tag = template.format(
+            interpreter=interpreter_id,
+            abi="abi3",
+            platform=sysconfig.get_platform(),
+        )
+        if abi3_tag in tags.compatible_tags():
+            py_limited_api = interpreter_id
+        else:
+            py_limited_api = None
 
+    if py_limited_api is not None:
         if "DIST_EXTRA_CONFIG" in os.environ:
             raise ValueError(
                 "Cannot use EXTENSION_HELPERS_PY_LIMITED_API if DIST_EXTRA_CONFIG is already defined"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
+    "packaging>=25.0",
     "setuptools>=64",
     "tomli>=1.0.0 ; python_version < '3.11'",
 ]


### PR DESCRIPTION
This is at a proof-of-concept stage: I haven't bothered writing tests for it yet, but I wanted to bring it up because I always feel like this feature is missing, and while complicated to implement right in the general case, it so happens that I wrote [a small library](https://github.com/neutrinoceros/runtime-introspect) that already does the heavy lifting needed to determine whether it is safe to build abi3 binaries in a portable fashion, so, before I commit more time to it, does it sound worth an extra dependency to others ? 